### PR TITLE
Flamescans: added override, fixed ids, incremented version

### DIFF
--- a/src/FlameScans/FlameScans.ts
+++ b/src/FlameScans/FlameScans.ts
@@ -20,7 +20,7 @@ import { Parser } from './parser'
 const FS_DOMAIN = 'https://flamescans.org'
 
 export const FlameScansInfo: SourceInfo = {
-    version: '2.0.5',
+    version: '2.0.6',
     name: 'FlameScans',
     description: 'Extension that pulls manga from Flame Scans.',
     author: 'NmN',
@@ -71,7 +71,7 @@ export class FlameScans extends Source {
     RETRY = 5
     parser = new Parser()
 
-    getMangaShareUrl(mangaId: string): string {
+    override getMangaShareUrl(mangaId: string): string {
         return `${this.baseUrl}/series/${mangaId}`
     }
 
@@ -88,7 +88,7 @@ export class FlameScans extends Source {
 
     async getChapters(mangaId: string): Promise<Chapter[]> {
         const request = createRequestObject({
-            url: `${this.baseUrl}/abc/series/${mangaId}`,
+            url: `${this.baseUrl}/series/${mangaId}`,
             method: 'GET',
         })
 
@@ -100,7 +100,7 @@ export class FlameScans extends Source {
 
     async getChapterDetails(mangaId: string, chapterId: string): Promise<ChapterDetails> {
         const request = createRequestObject({
-            url: chapterId,
+            url:  `${this.baseUrl}/${chapterId}`,
             method: 'GET',
         })
 

--- a/src/FlameScans/parser.ts
+++ b/src/FlameScans/parser.ts
@@ -62,13 +62,13 @@ export class Parser {
         const chapters: Chapter[] = []
         const arrChapters = $('#chapterlist li').toArray().reverse()
         for (const item of arrChapters) {
-            const id = $('a', item).attr('href') ?? ''
+            const id = $('a', item).attr('href').replace(/\/$/, '').split('/').pop() ?? ''
             const chapNum = Number($(item).attr('data-num') ?? '0')
 
             const time = source.convertTime($('.chapterdate', item).text().trim())
             chapters.push(
                 createChapter({
-                    id,
+                    id: this.trimId(id),
                     mangaId,
                     name: `Chapter ${chapNum.toString()}`,
                     chapNum,
@@ -102,7 +102,7 @@ export class Parser {
         const results: MangaTile[] = []
 
         for (const item of $('.listupd .bsx').toArray()) {
-            const id    = $('a', item).attr('href')?.split("series")[1].replace(/^\/|\/$/g, '') ?? ''
+            const id    = $('a', item).attr('href')?.split('series')[1].replace(/^\/|\/$/g, '') ?? ''
             const title = $('a', item).attr('title') ?? ''
             const image = $('img', item).attr('src') ?? ''
             results.push(
@@ -119,7 +119,7 @@ export class Parser {
     parseViewMore($: any): MangaTile[] {
         const more: MangaTile[] = []
         for (const item of $('.listupd .bsx').toArray()) {
-            const id    = $('a', item).attr('href')?.split("series")[1].replace(/^\/|\/$/g, '') ?? ''
+            const id    = $('a', item).attr('href')?.split('series')[1].replace(/^\/|\/$/g, '') ?? ''
             const title = $('a', item).attr('title') ?? ''
             const image = $('img', item).attr('src') ?? ''
             more.push(
@@ -147,14 +147,13 @@ export class Parser {
         const arrLatest   = $('.latest-updates .bsx').toArray()
 
         for (const obj of arrFeatured) {
-            const id     = $(obj).attr('href')?.split("series")[1].replace(/^\/|\/$/g, '') ?? ''
-            console.log(id)
+            const id     = $(obj).attr('href')?.split('series')[1].replace(/^\/|\/$/g, '') ?? ''
             const title  = $('.tt', obj).text().trim()
             const strImg = $('.bigbanner', obj).attr('style') ?? ''
             const image  = strImg.substring(23, strImg.length - 3) ?? ''
             featured.push(
                 createMangaTile({
-                    id,
+                    id: this.trimId(id),
                     image,
                     title: createIconText({ text: this.encodeText(title) }),
                 })
@@ -165,12 +164,12 @@ export class Parser {
 
 
         for (const item of arrLatest) {
-            const id    = $('a', item).attr('href')?.split("series")[1].replace(/^\/|\/$/g, '') ?? ''
+            const id    = $('a', item).attr('href')?.split('series')[1].replace(/^\/|\/$/g, '') ?? ''
             const title = $('a', item).attr('title') ?? ''
             const image = $('img', item).attr('src') ?? ''
             latest.push(
                 createMangaTile({
-                    id,
+                    id: this.trimId(id),
                     image,
                     title: createIconText({ text: this.encodeText(title) }),
                 })
@@ -181,13 +180,13 @@ export class Parser {
         sectionCallback(section2)
 
         for (const obj of arrPopular) {
-            const id      = $('a', obj).attr('href')?.split("series")[1].replace(/^\/|\/$/g, '') ?? ''
+            const id      = $('a', obj).attr('href')?.split('series')[1].replace(/^\/|\/$/g, '') ?? ''
             const title   = $('a', obj).attr('title') ?? ''
             const subText = $('.status', obj).text() ?? ''
             const image   = $('img', obj).attr('src') ?? ''
             popular.push(
                 createMangaTile({
-                    id,
+                    id: this.trimId(id),
                     image,
                     title: createIconText({ text: this.encodeText(title) }),
                     subtitleText: createIconText({ text: subText }),
@@ -196,6 +195,14 @@ export class Parser {
         }
         section3.items = popular
         sectionCallback(section3)
+    }
+
+    trimId(id: string): string {
+        const idSplit = id.split('-')
+        if (Number(idSplit[0])) {
+            return idSplit.slice(1).join('-')
+        }
+        return id
     }
 
     encodeText(str: string) {


### PR DESCRIPTION
Fixed chapter id parsing by removing the numeric part of the id that was the issue. Removed hardcoded /abc/ redirect as the website and app redirects from base series path anyway. This should stop chapterIds and Title Ids from refreshing everyday. Removed use of the whole url as chapter id for chapter preservation purposes. Added trimId function in parser to take care of removal of numeric part of url id path.